### PR TITLE
compatibility update to SkyID 1.4.*

### DIFF
--- a/src/services/skyidapp/connect.js
+++ b/src/services/skyidapp/connect.js
@@ -81,19 +81,17 @@ window.SkyidConnect = class SkyidConnect {
 	addDapp(appId, appData, callback) {
 		// fetch file
 		var self = this;
-		this.skyid.getJSON('profile', function (response, revision) {
-			if (response == '') { // file not found
+		this.skyid.getJSON('profile', function (profileObj) {
+			if (profileObj == null) { // file not found
 				alert('Error: unable to fetch dapp list')
 				console.log('Error: unable to fetch dapp list')
 			} else { // success
-				var profileObj = JSON.parse(response)
 				if (typeof profileObj.dapps == 'undefined') {
 					profileObj.dapps = {}
 				}
 				profileObj.dapps[appId] = appData
 
 				// set file
-				let jsonProfile = JSON.stringify(profileObj)
 				self.skyid.setJSON('profile', profileObj, function (success) {
 					if (!success) {
 						alert('Error: unable to save profile.json')


### PR DESCRIPTION
Hi nathanganser!

I saw you're using your own SkyID instead of `https://sky-id.hns.siasky.net/skyid.js` so this update is only neede if you also update SkyID to 0.4.*

Fixed a compatibility issue: the new `skyid.setJSON()` function expects a Javascript object instead of a JSON string. Same with `skyid.getJSON()`, it returns an object instead of a JSON string. [More info](https://github.com/DaWe35/SkyID/blob/main/CHANGELOG.md#2021-06)

**I did not make any tests, this pr is just a suggestion/help**